### PR TITLE
FAQ: Remove suggestion to comment on locked issues

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -109,7 +109,7 @@ Here are some behaviors that may look like bugs, but aren't.
 > I want to request one of the following features...
 
 Here's a list of common feature requests and their corresponding issue.
-Please leave comments in these rather than logging new issues.
+Before opening a new request, please read up on prior discussions of the feature you wish to propose.
 * Safe navigation operator, AKA CoffeeScript's null conditional/propagating/propagation operator, AKA C#'s' `?.` operator [#16](https://github.com/Microsoft/TypeScript/issues/16)
 * Minification [#8](https://github.com/Microsoft/TypeScript/issues/8)
 * Extension methods [#9](https://github.com/Microsoft/TypeScript/issues/9)


### PR DESCRIPTION
The § Common Feature Requests opens:
> Here's a list of common feature requests and their corresponding issue. Please leave comments in these rather than logging new issues.

The only problem is, nearly all of those issues (and the ones they link to, in the case of aggregate/tracking issues) have been bot-locked, so users _can't_ leave comments there.

This PR rewrites the second sentence to encourage simply _reading_, rather than commenting on, the closed/locked issues.